### PR TITLE
Fix incompatabilities in linux

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -84,7 +84,7 @@ int add_command(int argc, char **argv)
         }
 
         // arguments points to a item in argv
-        char *id = strdup(arg_list->arguments[0]);
+        char *id = duplicate_string(arg_list->arguments[0]);
 
         destroy_argument_list(arg_list);
 

--- a/src/data.c
+++ b/src/data.c
@@ -143,7 +143,7 @@ struct todo_data *read_todo_from_file(FILE *todo_file)
                 goto return_err;
         }
 
-        id = strdup(buffer);
+        id = duplicate_string(buffer);
 
         // Get priority
         segment = strtok(NULL, ";");
@@ -162,7 +162,7 @@ struct todo_data *read_todo_from_file(FILE *todo_file)
         }
 
         if (is_custom) {
-                char *state_string = strdup(segment);
+                char *state_string = duplicate_string(segment);
                 state = create_custom_state_data(true, state_string);
 
                 state->is_custom = is_custom;
@@ -182,7 +182,7 @@ struct todo_data *read_todo_from_file(FILE *todo_file)
                 goto return_err;
         }
 
-        subject = strdup(segment);
+        subject = duplicate_string(segment);
 
         // Get the description
         segment = strtok(NULL, ";");
@@ -191,7 +191,7 @@ struct todo_data *read_todo_from_file(FILE *todo_file)
                 goto return_err;
         }
 
-        description = strdup(segment);
+        description = duplicate_string(segment);
 
         todo = create_todo_data(id, priority, state, subject, description);
 

--- a/src/util.c
+++ b/src/util.c
@@ -68,8 +68,8 @@ size_t directory_iterator(const char *directory_path, file_callback_t callback)
 
         while ((entry = readdir(stream)) != NULL) {
                 // Ignore entries '.' and '..'
-                if (strncmp(entry->d_name, ".", 2) != 0
-                    || strncmp(entry->d_name, "..", 2) != 0) {
+                if (strncmp(entry->d_name, ".", 2) < 0
+                    || strncmp(entry->d_name, "..", 2) < 0) {
                         continue;
                 }
 


### PR DESCRIPTION
Linux under strict c99 does not include the strdup function. Replace it
with our own duplicate_string function. Also strncmp returns < 0 when a
match is not found. These issues caused compilation errors and incorrect
behavior in the application

Signed-off-by: Chris Frank <chris@cfrank.org>